### PR TITLE
OQ_ButtonPressable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .import
 src_data
+.DS_STORE

--- a/OQ_Toolkit/OQ_Interactables/OQ_ButtonPressable.tscn
+++ b/OQ_Toolkit/OQ_Interactables/OQ_ButtonPressable.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://scripts/OQ_ButtonPressable.gd" type="Script" id=2]
+[ext_resource path="res://materials/bright_metal.tres" type="Material" id=4]
+
+[sub_resource type="CubeMesh" id=1]
+
+[sub_resource type="BoxShape" id=2]
+margin = 0.001
+extents = Vector3( 0.0290335, 0.0168922, 0.00678976 )
+
+[node name="OQ_ButtonPressable" type="Spatial"]
+transform = Transform( 1, 1.49012e-08, 0, 0, 1, -5.96046e-08, 0, 0, 1, 0, 0, 0 )
+script = ExtResource( 2 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+transform = Transform( 0.0283254, -1.16415e-09, -2.32831e-10, 1.86265e-09, 0.0159037, 3.95812e-09, 2.79397e-09, -1.00117e-08, 0.00740362, 0, 0, 0 )
+mesh = SubResource( 1 )
+material/0 = ExtResource( 4 )
+
+[node name="ButtonArea" type="Area" parent="."]
+
+[node name="CollisionShape" type="CollisionShape" parent="ButtonArea"]
+shape = SubResource( 2 )

--- a/OQ_Toolkit/OQ_Interactables/scripts/OQ_ButtonPressable.gd
+++ b/OQ_Toolkit/OQ_Interactables/scripts/OQ_ButtonPressable.gd
@@ -1,0 +1,110 @@
+extends Spatial
+
+# a button that needs to be physically pressed
+class_name ButtonPressable
+
+signal button_pressed
+
+var touching := false
+var at_default_pos := true
+var triggering := false
+var is_on := false
+var hand_area: Area
+var button_half_length_vector
+var hand_pos: Vector3
+var prev_hand_pos: Vector3
+var dist := 0.0
+var lerp_weight: float
+var start_time := 0.0
+var speed := 2.0
+
+onready var initial_pos_local: = get_transform().origin
+onready var initial_pos_global: = get_global_transform().origin
+onready var button_forward_vector_norm = get_transform().basis.z.normalized()
+onready var z_scale = scale.z
+onready var button_mesh := $MeshInstance
+
+export var press_distance := 0.008
+export(Material) var off_material
+export(Material) var on_material
+export var on_on_start := false
+
+
+func _ready():
+	# connect to signals
+	$ButtonArea.connect("area_entered", self, "_on_ButtonArea_area_entered")
+	$ButtonArea.connect("area_exited", self, "_on_ButtonArea_area_exited")
+	
+	button_half_length_vector = initial_pos_local + button_forward_vector_norm * z_scale / 2
+	
+	# switch to correct material
+	if (on_on_start):
+		is_on = true
+	switch_mat(is_on)
+
+
+func _process(delta):
+	
+	if touching:
+		# if hand is touching the button, we need to know how far in it is pressed
+		
+		# check how much hand pos has changed in buttons local z direction
+		hand_pos = hand_area.global_transform.origin
+		var hand_pos_change = hand_pos - prev_hand_pos
+		
+		var hand_pos_change_z_component = hand_pos_change.slide(button_forward_vector_norm)
+		dist = hand_pos_change_z_component.length()
+		var new_origin = Vector3(initial_pos_local.x, initial_pos_local.y, transform.origin.z - dist)
+		
+		# only keep pushing back until press_distance is reached
+		if initial_pos_local.z - new_origin.z < press_distance:
+			transform.origin = new_origin
+		elif !triggering:
+			# trigger button press
+			triggering = true
+			button_press(hand_area)
+		
+		prev_hand_pos = hand_pos
+
+	elif !at_default_pos:
+		# if not touching and not at default pos, bring back to default pos
+		lerp_weight = start_time / speed
+		var move_by = lerp(dist, 0, lerp_weight)
+		
+		var new_origin = Vector3(initial_pos_local.x, initial_pos_local.y, initial_pos_local.z + move_by)
+		
+		transform.origin = new_origin
+		
+		start_time += delta
+		
+		if lerp_weight > 0:
+			start_time = 0.0
+			at_default_pos = true
+			triggering = false
+		
+
+
+func _on_ButtonArea_area_entered(area):
+	touching = true
+	at_default_pos = false
+	hand_area = area
+	
+	hand_pos = hand_area.global_transform.origin
+	prev_hand_pos = hand_area.global_transform.origin
+
+
+func _on_ButtonArea_area_exited(area):
+	touching = false
+
+
+func button_press(other_area: Area):
+	is_on = !is_on
+	switch_mat(is_on)
+	emit_signal("button_pressed")
+
+
+func switch_mat(_is_on):
+	if _is_on:
+		button_mesh.set_material_override(on_material)
+	else:
+		button_mesh.set_material_override(off_material)

--- a/project.godot
+++ b/project.godot
@@ -8,9 +8,14 @@
 
 config_version=4
 
-_global_script_classes=[  ]
+_global_script_classes=[ {
+"base": "Spatial",
+"class": "ButtonPressable",
+"language": "GDScript",
+"path": "res://OQ_Toolkit/OQ_Buttons/scripts/OQ_ButtonPressable.gd"
+} ]
 _global_script_class_icons={
-
+"ButtonPressable": ""
 }
 
 [application]
@@ -103,6 +108,6 @@ quality/shading/force_vertex_shading.mobile=false
 quality/shading/force_lambert_over_burley=true
 quality/shading/force_blinn_over_ggx.mobile=false
 environment/default_clear_color=Color( 0, 0, 0, 1 )
-quality/filters/msaa=6
+quality/filters/msaa=2
 quality/depth/hdr=false
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
Adds a scene and script with a (physically) pressable button.
Features:
- Setable press distance (how deep you need to press it)
- Choosable materials for on and off state
- Bool if initial state is off or on (off is default)
- Emits `button_pressed` signal

To be added/improved:
- If you remove hand slowly, it jitters a bit
- Press/click sound