### PR TITLE
Fix some scenes not fading all the way out

### DIFF
--- a/OQ_Toolkit/vr_autoload.gd
+++ b/OQ_Toolkit/vr_autoload.gd
@@ -578,7 +578,7 @@ func _check_for_scene_switch_and_fade(dt):
 	switch_scene_in_progress = false;
 	if (_target_scene_path != null && !_switch_performed):
 		if (_scene_switch_fade_out_time < _scene_switch_fade_out_duration):
-			var c = 1.0 - _scene_switch_fade_out_time / _scene_switch_fade_out_duration;
+			var c = 1.0 - min(1.0, _scene_switch_fade_out_time / (_scene_switch_fade_out_duration*0.9));
 			set_default_layer_color_scale(Color(c, c, c, c));
 			_scene_switch_fade_out_time += dt;
 			switch_scene_in_progress = true;


### PR DESCRIPTION
Some of my scenes would show the final pre-black image frozen. This change causes use to bit pure black slightly earlier than the total fade time, thus guaranteeing that we hit full black a frame or two before starting to load the next scene.