### PR TITLE
Still process raycast on the loop when it ceases to be visible

### DIFF
--- a/OQ_Toolkit/OQ_ARVRController/scripts/Feature_UIRayCast.gd
+++ b/OQ_Toolkit/OQ_ARVRController/scripts/Feature_UIRayCast.gd
@@ -44,18 +44,19 @@ func _update_raycasts():
 	ui_raycast_hitmarker.visible = false;
 	
 	
-		
 	if (controller.is_hand && vr.ovrHandTracking): # hand has separate logic
 		ui_raycast_mesh.visible = vr.ovrHandTracking.is_pointer_pose_valid(controller.controller_id);
+		if (!ui_raycast_mesh.visible): return;
 	elif (ui_raycast_visible_button == vr.CONTROLLER_BUTTON.None ||
 		  controller._button_pressed(ui_raycast_visible_button) ||
 		  controller._button_pressed(ui_raycast_click_button)): 
 		ui_raycast_mesh.visible = true;
 	else:
+		# Process when raycast just starts to not be visible,
+		# To allow for button release
+		if (!ui_raycast_mesh.visible): return;
 		ui_raycast_mesh.visible = false;
 		
-	if (!ui_raycast_mesh.visible): return;
-	
 	_set_raycast_transform();
 
 		


### PR DESCRIPTION
This allows for Release events to fire, especially when using the Feature_VRSimulator when releasing the left mouse button releases the virtual controller trigger and updates visibility at the same time.

Before this change, "pressed" events would propagate into the canvas elements, but "release" events would nearly always not fire.