### PR TITLE
PC Oculus should bet set to 90Hz

### DIFF
--- a/OQ_Toolkit/vr_autoload.gd
+++ b/OQ_Toolkit/vr_autoload.gd
@@ -879,7 +879,10 @@ func initialize(initialize_vr = true):
 		if arvr_oculus_interface.initialize():
 			active_arvr_interface_name = "Oculus";
 			get_viewport().arvr = true;
-			Engine.target_fps = 80 # TODO: this is headset dependent (RiftS == 80)=> figure out how to get this info at runtime
+			# Oculus on PC appears to select the correct refresh rate automatically.
+			# Rift and Quest 2 via Link can handle 90 Hz, but Quest 1 via link and Rift S will run at 72 and 80 respectively.
+			# Setting this below 90 will cap Q2 and Rift to what ever that is set to which is not ideal.
+			Engine.target_fps = 90
 			OS.vsync_enabled = false;
 			inVR = true;
 			log_info("  Success initializing Oculus Interface.");


### PR DESCRIPTION
Oculus on PC will respect `target_fps` as a maximum, but it will automatically turn down the fps to what ever the HMD requires.
Thus setting this to the maximum of 90Hz will allow those HMDs to run at their proper rate, and Oculus will handle reducing it for other HMDs that need a lower rate.

When this was set to 80Hz, the original Rift would run at 80Hz, increasing this to 90Hz allowed it to run at it's native refresh rate of 90.

Tested on Quest 1 and 2 via link, and Oculus automatically lowers the refresh rate to 72Hz.