### PR TITLE
remove the need for clearing the bone rest pose

### DIFF
--- a/demo_scenes/HandTrackingDemoScene.gd
+++ b/demo_scenes/HandTrackingDemoScene.gd
@@ -18,5 +18,6 @@ func _process(_dt):
 
 
 func _ready():
-	pass # Replace with function body.
+	vr.initialize();
+
 

--- a/demo_scenes/HandTrackingDemoScene.gd
+++ b/demo_scenes/HandTrackingDemoScene.gd
@@ -18,6 +18,5 @@ func _process(_dt):
 
 
 func _ready():
-	vr.initialize();
-
+	pass
 

--- a/project.godot
+++ b/project.godot
@@ -57,7 +57,7 @@ _global_script_class_icons={
 [application]
 
 config/name="Godot Oculus Quest Toolkit Demo"
-run/main_scene="res://GameMain.tscn"
+run/main_scene="res://demo_scenes/HandTrackingDemoScene.tscn"
 config/icon="res://icon.png"
 
 [autoload]
@@ -71,7 +71,7 @@ window/size/height=540
 
 [gdnative]
 
-singletons=[ "res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" ]
+singletons=[ "res://addons/godot-openvr/godot_openvr.gdnlib", "res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" ]
 
 [importer_defaults]
 
@@ -144,8 +144,8 @@ quality/reflections/high_quality_ggx=false
 quality/shading/force_vertex_shading.mobile=false
 quality/shading/force_lambert_over_burley=true
 quality/shading/force_blinn_over_ggx.mobile=false
-quality/lightmapping/use_bicubic_sampling=false
 environment/default_clear_color=Color( 0, 0, 0, 1 )
 quality/filters/msaa=6
 quality/depth/hdr=false
 environment/default_environment="res://default_env.tres"
+quality/lightmapping/use_bicubic_sampling=false

--- a/project.godot
+++ b/project.godot
@@ -57,7 +57,7 @@ _global_script_class_icons={
 [application]
 
 config/name="Godot Oculus Quest Toolkit Demo"
-run/main_scene="res://demo_scenes/HandTrackingDemoScene.tscn"
+run/main_scene="res://GameMain.tscn"
 config/icon="res://icon.png"
 
 [autoload]
@@ -71,7 +71,8 @@ window/size/height=540
 
 [gdnative]
 
-singletons=[ "res://addons/godot-openvr/godot_openvr.gdnlib", "res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" ]
+singletons=[ "res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" ]
+singletons_disabled=[  ]
 
 [importer_defaults]
 


### PR DESCRIPTION
This should deal with https://github.com/NeoSpark314/godot_oculus_quest_toolkit/issues/60

(also you need vr.initialize() in the ready function of the HandTrackingDemo scene or it doesn't work on its own)